### PR TITLE
Add support for KopernicusSolarPanel to power calc

### DIFF
--- a/Fusebox/Core.cs
+++ b/Fusebox/Core.cs
@@ -404,6 +404,7 @@ namespace Ratzap
                     switch (tmpPM.moduleName)
                     {
                         case "ModuleDeployableSolarPanel":
+                        case "KopernicusSolarPanel":
                             if (typeArr[0])
                             {
                                 ModuleDeployableSolarPanel tmpSol = (ModuleDeployableSolarPanel)tmpPM;


### PR DESCRIPTION
**Note: This edit is not tested since I don't have a dev environment for KSP mods set up.**

That said, KopernicusSolarPanel inherits ModuleSolarPanel (see https://github.com/Kopernicus/Kopernicus/blob/master/Kopernicus/Kopernicus.Components/KopernicusSolarPanel.cs), and updates the flowRate field, so there shouldn't be any issues.