### PR TITLE
fixed typo in InstallCheck.cs

### DIFF
--- a/Fusebox/InstallChecker.cs
+++ b/Fusebox/InstallChecker.cs
@@ -42,7 +42,7 @@ namespace Ratzap
     internal class InstallChecker : MonoBehaviour
     {
         private const string MODNAME = "FuseBox Continued";
-        private const string FOLDERNAME = "FuseBoxContinued";
+        private const string FOLDERNAME = "FuseboxContinued";
         private const string EXPECTEDPATH = FOLDERNAME + "/Plugins";
 
         protected void Start()


### PR DESCRIPTION
Fixed a typo in InstallChecker.cs that was causing this issue reported on the forum thread:

https://forum.kerbalspaceprogram.com/index.php?/topic/157896-18x-fusebox-continued-electric-charge-tracker-and-build-helper/&do=findComment&comment=3717088