### PR TITLE
Add support for weatherDrivenSolarPanel to power calc

### DIFF
--- a/Fusebox/Core.cs
+++ b/Fusebox/Core.cs
@@ -384,6 +384,7 @@ namespace Ratzap
                         case "ModuleDeployableSolarPanel":
                         case "KopernicusSolarPanel":
                         case "weatherDrivenSolarPanelStock":
+                        case "weatherDrivenSolarPanelRO":
                             if (typeArr[0])
                             {
                                 ModuleDeployableSolarPanel tmpSol = (ModuleDeployableSolarPanel)tmpPM;

--- a/Fusebox/Core.cs
+++ b/Fusebox/Core.cs
@@ -383,6 +383,7 @@ namespace Ratzap
                     {
                         case "ModuleDeployableSolarPanel":
                         case "KopernicusSolarPanel":
+                        case "weatherDrivenSolarPanelStock":
                             if (typeArr[0])
                             {
                                 ModuleDeployableSolarPanel tmpSol = (ModuleDeployableSolarPanel)tmpPM;


### PR DESCRIPTION
Something like https://github.com/linuxgurugamer/FuseBoxContinued/pull/10. I haven't tested it though, in theory WDSP takes the same EC calculations as KopernicusSolarPanel, so it should be able to be calculated as well.
